### PR TITLE
fix raise_ex

### DIFF
--- a/pythonx/ncm2_pyclang_proc.py
+++ b/pythonx/ncm2_pyclang_proc.py
@@ -69,7 +69,7 @@ class Source(Ncm2Source):
             except Exception as ex:
                 from neovim import Nvim
                 nvim = self.nvim  # type: Nvim
-                def raise_ex():
+                class raise_ex():
                     raise ex
                 nvim.async_call(raise_ex)
             finally:


### PR DESCRIPTION
if use `def raise_ex()`, it can't raise the right log #14